### PR TITLE
GRID-2280: :sparkles: Add more US Customary units

### DIFF
--- a/src/opengb/dram/quantity.cljc
+++ b/src/opengb/dram/quantity.cljc
@@ -40,7 +40,7 @@
 
 (def volume-intensity-unit? #{"l/m**2/year" "gal/ft**2/year"})
 
-(def per-year-unit? #{"kWh/year" "l/year"})
+(def per-year-unit? #{"kWh/year" "l/year" "gal/year"})
 
 (def thermal-transmittance-unit? #{"Btu/hr*ft**2*°F"
                                    "W/m**2*K"})
@@ -74,7 +74,8 @@
                           "lb/ft**2/year"
                           "kgCO₂e/ft²"
                           "kgCO₂e/ft²/year"
-                          "gal/ft**2/year"})
+                          "gal/ft**2/year"
+                          "gal/year"})
 
 (def semi-imperial-unit?
   "A hash set of the units that are used when viewing quantities in units that

--- a/src/opengb/dram/quantity.cljc
+++ b/src/opengb/dram/quantity.cljc
@@ -246,5 +246,6 @@
             "kgCO2e/m**2/year" "kgCO₂e/m²"
             "tCO2e/year"       "tCO₂e"
             "energystar"       ""
-            "year"             ""}]
+            "year"             ""
+            "gal/ft**2/year"   "gal/ft²/year"}]
     (get cs unit unit)))

--- a/src/opengb/dram/quantity.cljc
+++ b/src/opengb/dram/quantity.cljc
@@ -38,7 +38,7 @@
                             "t/ft**2/year" "lb/ft**2/year" "kgCO₂e/m²"
                             "kgCO₂e/m²/year" "kgCO₂e/ft²" "kgCO₂e/ft²/year"})
 
-(def volume-intensity-unit? #{"l/m**2/year"})
+(def volume-intensity-unit? #{"l/m**2/year" "gal/ft**2/year"})
 
 (def per-year-unit? #{"kWh/year" "l/year"})
 
@@ -73,7 +73,8 @@
                           "t/ft**2/year"
                           "lb/ft**2/year"
                           "kgCO₂e/ft²"
-                          "kgCO₂e/ft²/year"})
+                          "kgCO₂e/ft²/year"
+                          "gal/ft**2/year"})
 
 (def metric-unit? #{"m**2"
                     "kg/m**2/year"

--- a/src/opengb/dram/quantity.cljc
+++ b/src/opengb/dram/quantity.cljc
@@ -101,7 +101,8 @@
                     "kWh/year"
                     "l/year"
                     "kgCO₂e/m²"
-                    "kgCO₂e/m²/year"})
+                    "kgCO₂e/m²/year"
+                    "tCO₂e"})
 
 (s/def ::magnitude (s/or :int int?
                          :double (s/double-in :infinite? false :NaN? false)))

--- a/src/opengb/dram/quantity.cljc
+++ b/src/opengb/dram/quantity.cljc
@@ -79,11 +79,9 @@
                           "kBtu/year"})
 
 (def semi-imperial-unit?
-  "A hash set of the units that are used when viewing quantities in units that
-  are combinations of both Metric and US Customary units. Sometimes used in
-  Canada.
-  This hash set can be used as a predicate to test whether a unit belongs to
-  this particular system of measurement."
+  "A hash set of units that are combinations of other Metric and US Customary
+  units. Sometimes used in Canada. This hash set can be used as a predicate to
+  test whether a unit belongs to this particular system of measurement."
   #{"ft**2"
     "kWh/ft**2/year"
     "tCO₂e"

--- a/src/opengb/dram/quantity.cljc
+++ b/src/opengb/dram/quantity.cljc
@@ -76,6 +76,18 @@
                           "kgCO₂e/ft²/year"
                           "gal/ft**2/year"})
 
+(def semi-imperial-unit?
+  "A hash set of the units that are used when viewing quantities in units that
+  are combinations of both Metric and US Customary units. Sometimes used in
+  Canada.
+  This hash set can be used as a predicate to test whether a unit belongs to
+  this particular system of measurement."
+  #{"ft**2"
+    "kWh/ft**2/year"
+    "tCO₂e"
+    "kgCO₂e/ft²"
+    "l/ft**2/year"})
+
 (def metric-unit? #{"m**2"
                     "kg/m**2/year"
                     "t/m**2/year"
@@ -135,6 +147,8 @@
 (s/def ::pressure (s/and quantity? #(pressure-unit? (get-unit %))))
 
 (s/def ::us-customary (s/and quantity? #(us-customary-unit? (get-unit %))))
+
+(s/def ::semi-imperial (s/and quantity? #(semi-imperial-unit? (get-unit %))))
 
 (s/def ::metric (s/and quantity? #(metric-unit? (get-unit %))))
 

--- a/src/opengb/dram/quantity.cljc
+++ b/src/opengb/dram/quantity.cljc
@@ -35,7 +35,8 @@
 (def mass-per-year-unit? #{"t/year" "kg/year" "Mg/year" "lb/year" "tCO₂e" "tCO₂e/year"})
 
 (def mass-intensity-unit? #{"kg/m**2/year" "kg/ft**2/year" "t/m**2/year"
-                            "t/ft**2/year" "lb/ft**2/year" "kgCO₂e/m²" "kgCO₂e/m²/year"})
+                            "t/ft**2/year" "lb/ft**2/year" "kgCO₂e/m²"
+                            "kgCO₂e/m²/year" "kgCO₂e/ft²" "kgCO₂e/ft²/year"})
 
 (def volume-intensity-unit? #{"l/m**2/year"})
 
@@ -70,7 +71,9 @@
                           "kg/ft**2/year"
                           "kWh/ft**2/year"
                           "t/ft**2/year"
-                          "lb/ft**2/year"})
+                          "lb/ft**2/year"
+                          "kgCO₂e/ft²"
+                          "kgCO₂e/ft²/year"})
 
 (def metric-unit? #{"m**2"
                     "kg/m**2/year"
@@ -81,7 +84,9 @@
                     "kWh/m**2/year"
                     "l/m**2/year"
                     "kWh/year"
-                    "l/year"})
+                    "l/year"
+                    "kgCO₂e/m²"
+                    "kgCO₂e/m²/year"})
 
 (s/def ::magnitude (s/or :int int?
                          :double (s/double-in :infinite? false :NaN? false)))

--- a/src/opengb/dram/quantity.cljc
+++ b/src/opengb/dram/quantity.cljc
@@ -40,7 +40,7 @@
 
 (def volume-intensity-unit? #{"l/m**2/year" "gal/ft**2/year"})
 
-(def per-year-unit? #{"kWh/year" "l/year" "gal/year"})
+(def per-year-unit? #{"kWh/year" "l/year" "gal/year" "kBtu/year"})
 
 (def thermal-transmittance-unit? #{"Btu/hr*ft**2*°F"
                                    "W/m**2*K"})
@@ -75,7 +75,8 @@
                           "kgCO₂e/ft²"
                           "kgCO₂e/ft²/year"
                           "gal/ft**2/year"
-                          "gal/year"})
+                          "gal/year"
+                          "kBtu/year"})
 
 (def semi-imperial-unit?
   "A hash set of the units that are used when viewing quantities in units that


### PR DESCRIPTION
# Changes
- add US Customary units for water usage intensity, total water usage, energy usage intensity, total energy usage, and greenhouse gas emissions intensity
- add Metric units for greenhouse gas emissions instensity and total greenhouse gas emissions
- add units for the 'Semi-Imperial' measurement system that is available on GRID's public map
