### PR TITLE
[NO-TICKET] :bug: Format GHGIs for US Customary correctly

### DIFF
--- a/src/opengb/dram/quantity.cljc
+++ b/src/opengb/dram/quantity.cljc
@@ -300,6 +300,7 @@
             "kBtu/ft**2/year"  "kBtu/ft²/year"
             "ft**2"            "ft²"
             "kgCO2e/m**2/year" "kgCO₂e/m²"
+            "kgCO2e/ft**2/year" "kgCO₂e/ft²"
             "tCO2e/year"       "tCO₂e"
             "energystar"       ""
             "year"             ""


### PR DESCRIPTION
- GHGIs were showing up as `"kgCO2e/ft**2/year"`, which our formatting code didn't account for
- therefore add that unit to the formatting code
